### PR TITLE
Fix NormalSampling to use Normal distribution

### DIFF
--- a/src/FEM/ParamDataStructures/Sampling.jl
+++ b/src/FEM/ParamDataStructures/Sampling.jl
@@ -54,7 +54,8 @@ Sampling according to a normal distribution
 struct NormalSampling <: SamplingStyle end
 
 function generate_param(::NormalSampling,param_domain)
-  [rand(Uniform(first(d),last(d))) for d = param_domain]
+  μσ = [(first(d)+last(d))/2 => (last(d)-first(d))/6 for d = param_domain]
+  [rand(Normal(μ,σ)) for (μ,σ) = μσ]
 end
 
 """


### PR DESCRIPTION
Fix NormalSampling to use Normal distribution instead of Uniform

Fixes #28

I fixed a bug where `NormalSampling` was using `Uniform` distribution instead of `Normal` distribution in the `generate_param` function.

The implementation was identical to `UniformSampling` (likely a copy-paste oversight). I updated it to use `Normal(μ, σ)` where:
- `μ = (a + b) / 2` — midpoint of the domain
- `σ = (b - a) / 6` — ensures ~99.7% of samples fall within bounds

**Code:**
```julia
function generate_param(::NormalSampling,param_domain)
  μσ = [(first(d)+last(d))/2 => (last(d)-first(d))/6 for d = param_domain]
  [rand(Normal(μ,σ)) for (μ,σ) = μσ]
end
```