### PR TITLE
Fix get_mode2: use computed m2 matrix and abstract API accessors

### DIFF
--- a/src/FEM/ParamDataStructures/TransientSnapshots.jl
+++ b/src/FEM/ParamDataStructures/TransientSnapshots.jl
@@ -260,7 +260,7 @@ end
 function get_mode2(s::TransientSnapshots)
   mode1 = get_mode1(s)
   m2 = change_mode(mode1.data,num_params(s))
-  ModeTransientSnapshots(Mode2Axes(),s.data,s.dof_map,s.realization)
+  ModeTransientSnapshots(Mode2Axes(),m2,get_dof_map(s),get_realization(s))
 end
 
 function change_mode(a::AbstractMatrix,np::Integer)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ module GridapROMsTests
 
 using Test
 
+@testset "snapshots" begin include("snapshots.jl") end
+
 @testset "poisson" begin include("RBSteady/poisson.jl") end
 @testset "steady stokes" begin include("RBSteady/stokes.jl") end
 @testset "steady navier-stokes" begin include("RBSteady/navier_stokes.jl") end

--- a/test/snapshots.jl
+++ b/test/snapshots.jl
@@ -1,0 +1,26 @@
+module SnapshotsTests
+
+using Test
+using GridapROMs
+
+# Regression test: get_mode2 was constructing ModeTransientSnapshots with s.data
+# (an N-dimensional array) instead of the computed m2 matrix (2D). For any standard
+# TransientSnapshots backed by 3D+ data this caused a MethodError at the
+# ModeTransientSnapshots constructor, which requires A<:AbstractMatrix{T}.
+@testset "get_mode2 uses computed m2 matrix" begin
+  ns, np, nt = 5, 3, 4
+  params = Realization([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+  r = TransientRealization(params, [0.1, 0.2, 0.3, 0.4], 0.0)
+  i = VectorDofMap(ns)
+  data = reshape(collect(1.0:Float64(ns*np*nt)), ns, np, nt)
+  s = GenericSnapshots(data, i, r)
+
+  m2 = get_mode2(s)
+
+  @test isa(m2, ModeTransientSnapshots)
+  @test isa(get_all_data(m2), AbstractMatrix)
+  @test size(get_all_data(m2)) == (nt, ns * np)
+  @test get_all_data(m2) == change_mode(reshape(data, ns, :), np)
+end
+
+end # module


### PR DESCRIPTION
## Problem

`get_mode2` in `src/FEM/ParamDataStructures/TransientSnapshots.jl` had two bugs:

1. **Discarded computed result**: The function computed the mode-2 rearranged matrix `m2` via `change_mode` but never used it, passing raw `s.data` to the constructor instead.

2. **Direct field access**: Used `s.dof_map` and `s.realization` directly instead of abstract API methods, breaking compatibility with `TransientSnapshotsWithIC`.

### Impact
- **Crash**: MethodError on standard transient snapshots (3D data cannot satisfy `AbstractMatrix` constraint)
- **Silent corruption**: In rare cases where `s.data` was already 2D, wrong data layout was used, corrupting temporal basis extraction
- **Breaking subtype**: FieldError on `TransientSnapshotsWithIC` due to direct field access

---

## Fix

**File**: `src/FEM/ParamDataStructures/TransientSnapshots.jl`, line 263

**Changes**:
- ✅ `s.data` → `m2` — use the correctly computed mode-2 matrix
- ✅ `s.dof_map` → `get_dof_map(s)` — use abstract API
- ✅ `s.realization` → `get_realization(s)` — use abstract API

**Before**:
```julia
function get_mode2(s::TransientSnapshots)
  mode1 = get_mode1(s)
  m2 = change_mode(mode1.data, num_params(s))
  ModeTransientSnapshots(Mode2Axes(), s.data, s.dof_map, s.realization)  # ❌ wrong
end
```

**After**:
```julia
function get_mode2(s::TransientSnapshots)
  mode1 = get_mode1(s)
  m2 = change_mode(mode1.data, num_params(s))
  ModeTransientSnapshots(Mode2Axes(), m2, get_dof_map(s), get_realization(s))  # ✅ correct
end
```

---

## Testing

Added `test/snapshots.jl` with regression tests verifying:
- ✅ `get_mode2` succeeds without MethodError on 3D data
- ✅ Returned data is 2D (`AbstractMatrix`)
- ✅ Shape is correct: `(num_times, num_space_dofs × num_params)`
- ✅ Data layout matches expected mode-2 transformation (not raw data)

All tests use synthetic data and run in milliseconds.

---

## Verification

**Before fix**: Test would fail with MethodError
**After fix**: All assertions pass

This ensures the bug cannot be reintroduced through future refactoring.