### PR TITLE
[fix]: Replace permuterows!/invpermuterows! with indexed row operations

### DIFF
--- a/src/RB/RBSteady/BasesConstruction.jl
+++ b/src/RB/RBSteady/BasesConstruction.jl
@@ -48,15 +48,14 @@ function _cholesky_decomp(X::AbstractSparseMatrix)
 end
 
 function _forward_cholesky(A::AbstractMatrix,L::AbstractSparseMatrix,p::AbstractVector)
-  Base.permuterows!(A,p)
-  Ã = L'*A
-  Base.invpermuterows!(A,p)
+  Ã = L'*A[p,:]
   return Ã
 end
 
 function _backward_cholesky(Ã::AbstractMatrix,L::AbstractSparseMatrix,p::AbstractVector)
-  A = L'\Ã
-  Base.invpermuterows!(A,p)
+  Ap = L'\Ã
+  A = similar(Ap)
+  A[p,:] = Ap
   return A
 end
 


### PR DESCRIPTION
Fixes #44 

## Problem

The `_forward_cholesky` and `_backward_cholesky` functions call `Base.permuterows!` and `Base.invpermuterows!`, which don't exist in Julia 1.9 or 1.10.

**Broken code:**
```julia
function _forward_cholesky(A::AbstractMatrix, L::AbstractSparseMatrix, p::AbstractVector)
  Base.permuterows!(A, p)        # ❌ doesn't exist in Julia ≤ 1.10
  Ã = L' * A
  Base.invpermuterows!(A, p)
  return Ã
end
```

These functions were added in Julia 1.11+, but `Project.toml` declares `julia = "1.9"` as minimum. Every energy-norm POD reduction crashes on Julia 1.10 LTS with `UndefVarError: permuterows! not defined`.

---

## Impact

**What breaks:** All energy-norm POD workflows crash on Julia 1.9/1.10 (including LTS). This affects RBSteady/RBTransient tests for Poisson, Stokes, and Navier-Stokes.

**Why critical:** Energy-norm POD is the standard ROM approach. This breaks the primary workflow for anyone not on Julia 1.11+.

---

## Fix

Replaced with Julia 1.9+ compatible array indexing:

```julia
function _forward_cholesky(A::AbstractMatrix, L::AbstractSparseMatrix, p::AbstractVector)
  Ã = L' * A[p, :]  # ✅ works on Julia 1.9+
  return Ã
end

function _backward_cholesky(Ã::AbstractMatrix, L::AbstractSparseMatrix, p::AbstractVector)
  Ap = L' \ Ã
  A = similar(Ap)
  A[p, :] = Ap
  return A
end
```

Numerically identical, uses only Base operations, works on all declared Julia versions.

---

## After Fix

- ✅ Energy-norm POD works on Julia 1.9 and 1.10 LTS
- ✅ All RBSteady/RBTransient tests pass on supported Julia versions
- ✅ Package is truly compatible with declared minimum version