### PR TITLE
[Fix]: off-by-one in RBF Interpolator RHS assembly

### DIFF
--- a/src/RB/RBSteady/Interpolations.jl
+++ b/src/RB/RBSteady/Interpolations.jl
@@ -127,7 +127,7 @@ function RadialBasisFunctions.Interpolator(
   z = zero(data_type)
   for j in 1:l
     for i in 1:n
-      b[i,j] = i < k ? y.data[j,i] : z
+      b[i,j] = i ≤ k ? y.data[j,i] : z
     end
   end
   w = A \ b


### PR DESCRIPTION
Fix RBF interpolator off-by-one: include k-th training sample in RHS


## Problem

The RBF interpolator constructor has an off-by-one error in the RHS assembly loop that silently zeros the last training sample's target value.

**Broken code (line 130):**
```julia
for i in 1:n
  b[i,j] = i < k ? y.data[j,i] : z   # excludes i=k
end
```

The strict inequality `i < k` only assigns training data for rows 1 to k-1, leaving `b[k, j] = 0` instead of the actual training target.

---

## Impact

**Who is affected:** Every user of `RBFHyperReduction` for residual/Jacobian approximation in parametric ROMs.

**What breaks:**
- RBF interpolator doesn't reproduce training samples at training nodes (violates its defining property)
- Reduced residual/Jacobian approximations are biased
- ROM errors silently inflated
- For k=1 (single sample), interpolator collapses to constant zero function

**Silent failure:** No crash, no NaN - linear solve succeeds with corrupted RHS, output has valid dimensions but wrong values.

---

## Fix

**Changed:** `src/RB/RBSteady/Interpolations.jl`, line 130

One character: `i < k` → `i ≤ k`

```julia
for j in 1:l
  for i in 1:n
    b[i,j] = i ≤ k ? y.data[j,i] : z  # ✅ includes k-th sample
  end
end
```

The augmented RBF collocation system requires:
- Rows 1:k receive training target data
- Rows k+1:n receive zeros (polynomial augmentation constraints)

The fix ensures row k gets training data instead of being zeroed.

---

## After This Fix

- ✅ RBF interpolators correctly reproduce training nodes
- ✅ Reduced residual/Jacobian approximations are unbiased
- ✅ ROM error metrics reflect actual approximation quality
- ✅ k=1 edge case works (no longer degenerates to zero)